### PR TITLE
Added options object. Specify gulpRelative path.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,11 @@ var map = require('event-stream').map;
 
 var FILE_DECL = /(?:href=|src=|url\()['|"]([^\s>"']+?)\?rev=([^\s>"']+?)['|"]/gi;
 
-var revPlugin = function revPlugin() {
+var revPlugin = function revPlugin(options) {
+  var defaults = {
+    gulpRelative: false,
+  }
+  var options = Object.assign({}, defaults, options);
 
   return map(function(file, cb) {
 
@@ -38,7 +42,10 @@ var revPlugin = function revPlugin() {
       if(groups && groups.length > 1) {
         // are we an "absoulte path"? (e.g. /js/app.js)
         var normPath = path.normalize(groups[1]);
-        if (normPath.indexOf(path.sep) === 0) {
+        if (options.gulpRelative) {
+          dependencyPath = path.join('.', normPath);
+        }
+        else if (normPath.indexOf(path.sep) === 0) {
           dependencyPath = path.join(file.base, normPath);
         } 
         else {


### PR DESCRIPTION
I had the same issue a lot of people were having. If I specified a root-relative path in my html, the assets weren't being found and the script errored out.

I created an options obj that allows you to specify a `gulpRelative` flag, where the script takes a root-relative path and appends it to the pwd. Now it finds the assets even if your html is located in a different directory than the gulpfile. Assets get hashed. Much win.

Cheers!