### PR TITLE
Log file read errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ var revPlugin = function revPlugin() {
               line = line.replace(groups[2], hash.digest('hex'));
             }
             catch(e) {
-              // fail silently.
+              gutil.log(gutil.colors.red("Error: " + e));
             }
           }
           FILE_DECL.lastIndex = 0;


### PR DESCRIPTION
It is very inconvenient to fail silently on an error.

It might be better even to add an option to throw a PluginError when a file read fails - as this might break the build process.